### PR TITLE
performance tune

### DIFF
--- a/backend/src/meal_shield/app.py
+++ b/backend/src/meal_shield/app.py
@@ -1,4 +1,4 @@
-from typing import Optional, Final
+from typing import Final, Optional
 
 import nest_asyncio
 from fastapi import FastAPI, Query

--- a/backend/src/meal_shield/app.py
+++ b/backend/src/meal_shield/app.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Final
 
 import nest_asyncio
 from fastapi import FastAPI, Query
@@ -9,7 +9,7 @@ from meal_shield.scrape.scraping_and_excluding import scraping_and_excluding
 nest_asyncio.apply()
 
 app = FastAPI()
-WORDS = {
+WORDS: Final[dict[str, list[str]]] = {
     'えび': ['えび', 'エビ', '海老'],
     'かに': ['かに', 'カニ', '蟹'],
     '小麦': ['小麦'],

--- a/backend/src/meal_shield/ranking/ranking.py
+++ b/backend/src/meal_shield/ranking/ranking.py
@@ -61,7 +61,7 @@ async def ranking_recipe(
         scored_recipes_list = await scoring_embedding(
             allergies_list,
             excluded_recipes_list,
-            model_name='text-embedding-3-small',
+            model_name='text-embedding-3-large',
             score_column='embedding_score',
         )
         scored_recipes_list = scoring_count(

--- a/backend/src/meal_shield/scrape/cookpad.py
+++ b/backend/src/meal_shield/scrape/cookpad.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, Final
 import aiohttp
 import asyncio
 import requests
@@ -7,11 +7,11 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 from tqdm.asyncio import tqdm
 
 # 検索上限(page数)
-LIMIT_PAGE = 35
-MAX_RECIPE_SIZE = 100
-SEMAPHORE_LIMIT = 10  # 同時実行数の制限
+LIMIT_PAGE: Final[int] = 35
+MAX_RECIPE_SIZE: Final[int] = 100
+SEMAPHORE_LIMIT: Final[int] = 10
 
-semaphore = asyncio.Semaphore(SEMAPHORE_LIMIT)
+semaphore: asyncio.Semaphore = asyncio.Semaphore(SEMAPHORE_LIMIT)
 
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 async def scraping_cookpad(

--- a/backend/src/meal_shield/scrape/cookpad.py
+++ b/backend/src/meal_shield/scrape/cookpad.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union
-
 import aiohttp
+import asyncio
 import requests
 from bs4 import BeautifulSoup
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -9,7 +9,9 @@ from tqdm.asyncio import tqdm
 # 検索上限(page数)
 LIMIT_PAGE = 35
 MAX_RECIPE_SIZE = 100
+SEMAPHORE_LIMIT = 10  # 同時実行数の制限
 
+semaphore = asyncio.Semaphore(SEMAPHORE_LIMIT)
 
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 async def scraping_cookpad(
@@ -43,7 +45,6 @@ async def scraping_cookpad(
     else:
         return recipes_list[:MAX_RECIPE_SIZE]
 
-
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 def make_url_list(recipe_name: str) -> Optional[list[str]]:
     try:
@@ -70,72 +71,72 @@ def make_url_list(recipe_name: str) -> Optional[list[str]]:
     except Exception as e:
         return None
 
-
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 async def scraping_recipe_url(
     session: aiohttp.ClientSession, url: str
 ) -> Optional[list[str]]:
-    try:
-        async with session.get(url) as response:
-            response.raise_for_status()
-            content = await response.text()
-            soup = BeautifulSoup(content, 'lxml')
+    async with semaphore:
+        try:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                content = await response.text()
+                soup = BeautifulSoup(content, 'lxml')
 
-            recipe_url_list = []
-            # レシピのURLを属性に持つ<a>タグをすべて取得
-            a_tags = soup.find_all('a', class_='recipe-title')
-            for a_tag in a_tags:
-                # 各<a>タグのhref属性(URL)を取得
-                href = a_tag.get('href')
-                # 会員登録が必要なレシピを除外
-                if 'dining' not in href:
-                    recipe_url_list.append(f'https://cookpad.com{href}')
-            return recipe_url_list
-    except Exception as e:
-        return None
-
+                recipe_url_list = []
+                # レシピのURLを属性に持つ<a>タグをすべて取得
+                a_tags = soup.find_all('a', class_='recipe-title')
+                for a_tag in a_tags:
+                    # 各<a>タグのhref属性(URL)を取得
+                    href = a_tag.get('href')
+                    # 会員登録が必要なレシピを除外
+                    if 'dining' not in href:
+                        recipe_url_list.append(f'https://cookpad.com{href}')
+                return recipe_url_list
+        except Exception as e:
+            return None
 
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 async def scraping_recipe_data(
     session: aiohttp.ClientSession, url: str
 ) -> Optional[dict[str, Union[str, list[str]]]]:
-    try:
-        async with session.get(url) as response:
-            response.raise_for_status()
-            content = await response.text()
+    async with semaphore:
+        try:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                content = await response.text()
 
-            soup = BeautifulSoup(content, 'lxml')
+                soup = BeautifulSoup(content, 'lxml')
 
-            # レシピのタイトルである<h1>タグのテキストを取得
-            recipe_title = soup.find('h1', class_='recipe-title').get_text(strip=True)
-            # 全角スペースを半角スペースに置き換える
-            recipe_title = recipe_title.replace('\u3000', ' ')
+                # レシピのタイトルである<h1>タグのテキストを取得
+                recipe_title = soup.find('h1', class_='recipe-title').get_text(strip=True)
+                # 全角スペースを半角スペースに置き換える
+                recipe_title = recipe_title.replace('\u3000', ' ')
 
-            recipe_ingredients = []
-            # 材料のデータを含む<span>タグの要素をすべて取得
-            spans = soup.find_all('span', class_='name')
-            for span in spans:
-                # 材料は<span>タグかその中の<a>タグにあるので場合分け
-                a_tag = span.find('a')
-                if a_tag is None:
-                    ingredient_name = span.text
-                else:
-                    ingredient_name = a_tag.text
-                recipe_ingredients.append(ingredient_name)
+                recipe_ingredients = []
+                # 材料のデータを含む<span>タグの要素をすべて取得
+                spans = soup.find_all('span', class_='name')
+                for span in spans:
+                    # 材料は<span>タグかその中の<a>タグにあるので場合分け
+                    a_tag = span.find('a')
+                    if a_tag is None:
+                        ingredient_name = span.text
+                    else:
+                        ingredient_name = a_tag.text
+                    recipe_ingredients.append(ingredient_name)
 
-            # レシピ画像のURLを属性に持つ<img>タグを含む<section>タグを取得
-            section_tag = soup.find('section', id='main-photo')
-            # レシピ画像のURLを属性に持つ<img>タグを取得
-            img_tag = section_tag.find('img')
-            # <img>タグのsrc属性(レシピ画像のURL)を取得
-            recipe_image_url = img_tag.get('src')
+                # レシピ画像のURLを属性に持つ<img>タグを含む<section>タグを取得
+                section_tag = soup.find('section', id='main-photo')
+                # レシピ画像のURLを属性に持つ<img>タグを取得
+                img_tag = section_tag.find('img')
+                # <img>タグのsrc属性(レシピ画像のURL)を取得
+                recipe_image_url = img_tag.get('src')
 
-            recipe_data = {
-                'recipe_title': recipe_title,
-                'recipe_ingredients': recipe_ingredients,
-                'recipe_url': url,
-                'recipe_image_url': recipe_image_url,
-            }
-            return recipe_data
-    except Exception as e:
-        return None
+                recipe_data = {
+                    'recipe_title': recipe_title,
+                    'recipe_ingredients': recipe_ingredients,
+                    'recipe_url': url,
+                    'recipe_image_url': recipe_image_url,
+                }
+                return recipe_data
+        except Exception as e:
+            return None

--- a/backend/src/meal_shield/scrape/cookpad.py
+++ b/backend/src/meal_shield/scrape/cookpad.py
@@ -8,9 +8,9 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 from tqdm.asyncio import tqdm
 
 # 検索上限(page数)
-LIMIT_PAGE: Final[int] = 35
+LIMIT_PAGE: Final[int] = 40
 MAX_RECIPE_SIZE: Final[int] = 100
-SEMAPHORE_LIMIT: Final[int] = 10
+SEMAPHORE_LIMIT: Final[int] = 1000
 
 semaphore: asyncio.Semaphore = asyncio.Semaphore(SEMAPHORE_LIMIT)
 

--- a/backend/src/meal_shield/scrape/cookpad.py
+++ b/backend/src/meal_shield/scrape/cookpad.py
@@ -1,6 +1,7 @@
-from typing import Optional, Union, Final
-import aiohttp
 import asyncio
+from typing import Final, Optional, Union
+
+import aiohttp
 import requests
 from bs4 import BeautifulSoup
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -12,6 +13,7 @@ MAX_RECIPE_SIZE: Final[int] = 100
 SEMAPHORE_LIMIT: Final[int] = 10
 
 semaphore: asyncio.Semaphore = asyncio.Semaphore(SEMAPHORE_LIMIT)
+
 
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 async def scraping_cookpad(
@@ -45,6 +47,7 @@ async def scraping_cookpad(
     else:
         return recipes_list[:MAX_RECIPE_SIZE]
 
+
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 def make_url_list(recipe_name: str) -> Optional[list[str]]:
     try:
@@ -71,6 +74,7 @@ def make_url_list(recipe_name: str) -> Optional[list[str]]:
     except Exception as e:
         return None
 
+
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 async def scraping_recipe_url(
     session: aiohttp.ClientSession, url: str
@@ -95,6 +99,7 @@ async def scraping_recipe_url(
         except Exception as e:
             return None
 
+
 @retry(stop=stop_after_attempt(1), wait=wait_fixed(1), reraise=True)
 async def scraping_recipe_data(
     session: aiohttp.ClientSession, url: str
@@ -108,7 +113,9 @@ async def scraping_recipe_data(
                 soup = BeautifulSoup(content, 'lxml')
 
                 # レシピのタイトルである<h1>タグのテキストを取得
-                recipe_title = soup.find('h1', class_='recipe-title').get_text(strip=True)
+                recipe_title = soup.find('h1', class_='recipe-title').get_text(
+                    strip=True
+                )
                 # 全角スペースを半角スペースに置き換える
                 recipe_title = recipe_title.replace('\u3000', ' ')
 

--- a/frontend/src/meal_shield/search.py
+++ b/frontend/src/meal_shield/search.py
@@ -9,8 +9,9 @@ from meal_shield.env import PACKAGE_DIR
 base_url = 'http://backend:8000'
 
 
+BASE_IMAGE_URL = 'https://raw.githubusercontent.com/al22-1B-01/meal_shield/main/frontend/data/images/'
 # アレルギー品目の選択肢
-ALLERGY_OPTION = [
+_ALLERGY_OPTION = [
     {'name': 'えび', 'file': 'ebi.png'},
     {'name': 'かに', 'file': 'kani.png'},
     {'name': 'いか', 'file': 'ika.png'},
@@ -40,6 +41,7 @@ ALLERGY_OPTION = [
     {'name': 'りんご', 'file': 'ringo.png'},
     {'name': 'キウイフルーツ', 'file': 'kiwi.png'},
 ]
+ALLERGY_OPTION = [{'name': item['name'], 'file': BASE_IMAGE_URL + item['file']} for item in _ALLERGY_OPTION]
 
 
 def fetch_recipe_detail(recipe_name: str, allergies: list[str]) -> list:
@@ -75,7 +77,7 @@ def search_recipe_entrypoint() -> None:
         )
 
         col = cols[index % 7]
-        image = Image.open(PACKAGE_DIR / f'data/images/{item["file"]}')
+        # image = Image.open(PACKAGE_DIR / f'data/images/{item["file"]}')
 
         if col.button(item['name']):
             if item['name'] in st.session_state.allergy_list:
@@ -83,7 +85,8 @@ def search_recipe_entrypoint() -> None:
             else:
                 st.session_state.allergy_list.append(item['name'])
 
-        col.image(image, use_column_width=True, width=100)
+        # col.image(image, use_column_width=True, width=100)
+        col.image(item['file'], use_column_width=True, width=100)
 
     st.subheader('選択されたアレルギー品目')
     for allergy in st.session_state.allergy_list:

--- a/frontend/src/meal_shield/search.py
+++ b/frontend/src/meal_shield/search.py
@@ -1,5 +1,5 @@
-from typing import Final
 import time
+from typing import Final
 
 import requests
 import streamlit as st
@@ -8,8 +8,9 @@ import streamlit as st
 BASE_URL: Final[str] = 'http://localhost:8000'
 
 
-
-BASE_IMAGE_URL: Final[str] = 'https://raw.githubusercontent.com/al22-1B-01/meal_shield/main/frontend/data/images/'
+BASE_IMAGE_URL: Final[
+    str
+] = 'https://raw.githubusercontent.com/al22-1B-01/meal_shield/main/frontend/data/images/'
 # アレルギー品目の選択肢
 _ALLERGY_OPTION: Final[list[dict[str, str]]] = [
     {'name': 'えび', 'file': 'ebi.png'},
@@ -41,7 +42,10 @@ _ALLERGY_OPTION: Final[list[dict[str, str]]] = [
     {'name': 'りんご', 'file': 'ringo.png'},
     {'name': 'キウイフルーツ', 'file': 'kiwi.png'},
 ]
-ALLERGY_OPTION: Final[list[dict[str, str]]] = [{'name': item['name'], 'file': BASE_IMAGE_URL + item['file']} for item in _ALLERGY_OPTION]
+ALLERGY_OPTION: Final[list[dict[str, str]]] = [
+    {'name': item['name'], 'file': BASE_IMAGE_URL + item['file']}
+    for item in _ALLERGY_OPTION
+]
 
 
 def fetch_recipe_detail(recipe_name: str, allergies: list[str]) -> list:

--- a/frontend/src/meal_shield/search.py
+++ b/frontend/src/meal_shield/search.py
@@ -1,17 +1,17 @@
+from typing import Final
 import time
 
 import requests
 import streamlit as st
-from PIL import Image
 
-from meal_shield.env import PACKAGE_DIR
-
-base_url = 'http://backend:8000'
+# BASE_URL = 'http://backend:8000'
+BASE_URL: Final[str] = 'http://localhost:8000'
 
 
-BASE_IMAGE_URL = 'https://raw.githubusercontent.com/al22-1B-01/meal_shield/main/frontend/data/images/'
+
+BASE_IMAGE_URL: Final[str] = 'https://raw.githubusercontent.com/al22-1B-01/meal_shield/main/frontend/data/images/'
 # アレルギー品目の選択肢
-_ALLERGY_OPTION = [
+_ALLERGY_OPTION: Final[list[dict[str, str]]] = [
     {'name': 'えび', 'file': 'ebi.png'},
     {'name': 'かに', 'file': 'kani.png'},
     {'name': 'いか', 'file': 'ika.png'},
@@ -41,12 +41,12 @@ _ALLERGY_OPTION = [
     {'name': 'りんご', 'file': 'ringo.png'},
     {'name': 'キウイフルーツ', 'file': 'kiwi.png'},
 ]
-ALLERGY_OPTION = [{'name': item['name'], 'file': BASE_IMAGE_URL + item['file']} for item in _ALLERGY_OPTION]
+ALLERGY_OPTION: Final[list[dict[str, str]]] = [{'name': item['name'], 'file': BASE_IMAGE_URL + item['file']} for item in _ALLERGY_OPTION]
 
 
 def fetch_recipe_detail(recipe_name: str, allergies: list[str]) -> list:
     params = {'recipe': recipe_name, 'allergy_list': allergies}
-    response = requests.get(base_url, params=params)
+    response = requests.get(BASE_URL, params=params)
 
     if response.status_code == 200:
         return response.json()

--- a/frontend/src/meal_shield/search.py
+++ b/frontend/src/meal_shield/search.py
@@ -4,8 +4,7 @@ from typing import Final
 import requests
 import streamlit as st
 
-# BASE_URL = 'http://backend:8000'
-BASE_URL: Final[str] = 'http://localhost:8000'
+BASE_URL: Final[str] = 'http://backend:8000'
 
 
 BASE_IMAGE_URL: Final[

--- a/frontend/src/meal_shield/search.py
+++ b/frontend/src/meal_shield/search.py
@@ -77,7 +77,6 @@ def search_recipe_entrypoint() -> None:
         )
 
         col = cols[index % 7]
-        # image = Image.open(PACKAGE_DIR / f'data/images/{item["file"]}')
 
         if col.button(item['name']):
             if item['name'] in st.session_state.allergy_list:
@@ -85,7 +84,6 @@ def search_recipe_entrypoint() -> None:
             else:
                 st.session_state.allergy_list.append(item['name'])
 
-        # col.image(image, use_column_width=True, width=100)
         col.image(item['file'], use_column_width=True, width=100)
 
     st.subheader('選択されたアレルギー品目')


### PR DESCRIPTION
# WHY
- appの挙動が異常に悪いため
# WHAT
-  アレルギー画像をwebから取得
- スクレイピングのworker数を増加

# Result
- アレルギー画像 -> 目で見て早い
- スクレイピング -> 処理件数次第

実施前
```
Fetching recipe_urls: 100% 35/35 [00:02<00:00, 12.81it/s]
Fetching recipe_data: 100% 350/350 [00:16<00:00, 21.57it/s]
Processing recipes by ChatGPT:  87% 87/100 [00:01<00:00, 65.76it/s]ERROR:meal_shield.ranking.ranking_chatgpt:Failed to parse score: 'NoneType' object has no attribute 'group'
Processing recipes by ChatGPT: 100% 100/100 [00:02<00:00, 33.77it/s]
Processing recipes by embedding: 100% 100/100 [00:02<00:00, 36.39it/s]
Processing recipes by counting: 100% 100/100 [00:00<00:00, 163.92it/s]
```
実施後(worker=10, N_page=35)
```
Fetching recipe_urls: 100% 35/35 [00:03<00:00, 11.06it/s]
Fetching recipe_data: 100% 350/350 [00:18<00:00, 19.21it/s]
Processing recipes by ChatGPT: 100% 98/98 [00:04<00:00, 22.29it/s]
Processing recipes by embedding: 100% 98/98 [00:01<00:00, 91.30it/s]
Processing recipes by counting: 100% 98/98 [00:00<00:00, 166.31it/s]
```
実施後(worker=100, N_page=35)
```
Fetching recipe_urls: 100% 35/35 [00:02<00:00, 15.34it/s]
Fetching recipe_data: 100% 350/350 [00:16<00:00, 21.14it/s]
Processing recipes by ChatGPT:  53% 52/99 [00:01<00:00, 66.88it/s]ERROR:meal_shield.ranking.ranking_chatgpt:Failed to parse score: 'NoneType' object has no attribute 'group'
Processing recipes by ChatGPT:  88% 87/99 [00:01<00:00, 53.73it/s]ERROR:meal_shield.ranking.ranking_chatgpt:Failed to parse score: 'NoneType' object has no attribute 'group'
Processing recipes by ChatGPT: 100% 99/99 [00:02<00:00, 33.93it/s]
Processing recipes by embedding: 100% 99/99 [00:01<00:00, 78.23it/s]
Processing recipes by counting: 100% 99/99 [00:00<00:00, 200.73it/s]
```
実施後(worker=1000, N_page=35)
```
Fetching recipe_urls: 100% 35/35 [00:02<00:00, 15.50it/s]
Fetching recipe_data: 100% 350/350 [00:16<00:00, 20.94it/s]
Processing recipes by ChatGPT: 100% 96/96 [00:02<00:00, 33.76it/s]
Processing recipes by embedding: 100% 96/96 [00:02<00:00, 47.16it/s]
Processing recipes by counting: 100% 96/96 [00:00<00:00, 173.30it/s]
```
実施後(worker=1000, N_page=100)
```
Fetching recipe_urls: 100% 100/100 [00:05<00:00, 16.85it/s]
Fetching recipe_data: 100% 1000/1000 [00:48<00:00, 20.68it/s]
Processing recipes by ChatGPT: 100% 98/98 [00:02<00:00, 34.51it/s]
Processing recipes by embedding: 100% 98/98 [00:01<00:00, 51.07it/s]
Processing recipes by counting: 100% 98/98 [00:00<00:00, 174.99it/s]
```