### PR TITLE
set encoding

### DIFF
--- a/backend/src/meal_shield/scrape/cookpad.py
+++ b/backend/src/meal_shield/scrape/cookpad.py
@@ -55,7 +55,7 @@ def make_url_list(recipe_name: str) -> Optional[list[str]]:
         url = f'https://cookpad.com/search/{recipe_name}'
         response = requests.get(url)
         response.raise_for_status()
-        soup = BeautifulSoup(response.content, 'lxml')
+        soup = BeautifulSoup(response.content, 'lxml', from_encoding="utf-8")
         # 1 / 1,000のような現在のページを表す文字列を取得
         number_of_pages = soup.find(class_='number_of_pages').text
         page_parts = number_of_pages.split(' / ')
@@ -84,7 +84,7 @@ async def scraping_recipe_url(
             async with session.get(url) as response:
                 response.raise_for_status()
                 content = await response.text()
-                soup = BeautifulSoup(content, 'lxml')
+                soup = BeautifulSoup(content, 'lxml', from_encoding="utf-8")
 
                 recipe_url_list = []
                 # レシピのURLを属性に持つ<a>タグをすべて取得


### PR DESCRIPTION
# WHY
- スクレイピングのパフォーマンス改善
# WHAT
-  soupのencodingを指定
# Result
改善していないがおまじない程度にいれる
実施前
```
Fetching recipe_urls: 100% 100/100 [00:03<00:00, 26.38it/s]
Fetching recipe_data: 100% 1000/1000 [00:31<00:00, 31.43it/s]
Processing recipes by ChatGPT: 100% 1/1 [00:01<00:00,  1.29s/it]
Processing recipes by embedding: 100% 1/1 [00:00<00:00,  1.18it/s]
Processing recipes by counting: 100% 1/1 [00:00<00:00,  4.69it/s]
```
実施後
```
Fetching recipe_urls: 100% 100/100 [00:03<00:00, 25.86it/s]
Fetching recipe_data: 100% 1000/1000 [00:31<00:00, 32.11it/s]
Processing recipes by ChatGPT: 100% 6/6 [00:01<00:00,  3.56it/s]
Processing recipes by embedding: 100% 6/6 [00:00<00:00,  7.76it/s]
Processing recipes by counting: 100% 6/6 [00:00<00:00, 19.73it/s]
```